### PR TITLE
AEROGEAR-2491 - Don't force the use of the containerised apb tools in the Makefile 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build_and_push: apb_build docker_push apb_push
 
 .PHONY: apb_build
 apb_build:
-	docker run --rm --privileged -v $(PWD):/mnt:z -v $(HOME)/.kube:/.kube -v /var/run/docker.sock:/var/run/docker.sock -u $(USER) docker.io/ansibleplaybookbundle/apb-tools:latest prepare
+	apb prepare
 	docker build -t $(DOCKERHOST)/$(DOCKERORG)/$(IMAGENAME):$(TAG) .
 
 .PHONY: docker_push
@@ -20,7 +20,7 @@ docker_push:
 
 .PHONY: apb_push
 apb_push:
-	 docker run --rm --privileged -v $(PWD):/mnt:z -v $(HOME)/.kube:/.kube -v /var/run/docker.sock:/var/run/docker.sock -u $(USER) docker.io/ansibleplaybookbundle/apb-tools:latest push
+	apb push
 
 .PHONY: apb_release
 apb_release:

--- a/README.md
+++ b/README.md
@@ -13,20 +13,18 @@
 
 ## Developing
 
-After making your required changes, update the apb.yml to point at your own docker organisation, run:
+### Requirements
+
+- Setup OpenShift Origin [development environment](https://github.com/ansibleplaybookbundle/ansible-playbook-bundle/blob/master/docs/getting_started.md#development-environment) for APB development.
+- Install [apb tool](https://github.com/ansibleplaybookbundle/ansible-playbook-bundle/blob/master/docs/apb_cli.md)
+
+### Process
 
 ```bash
-make DOCKERORG=<your docker org> DOCKERHOST=<defaulting to docker.io>
+apb push
 ```
 
-**NOTE:**
-Due to our usage of an older version of the ASB, it is recommended using the `apb` CLI like the following:
-
-```bash
-alias apb='docker run --rm --privileged -v $PWD:/mnt -v $HOME/.kube:/.kube -v /var/run/docker.sock:/var/run/docker.sock -u $UID docker.io/ansibleplaybookbundle/apb-tools:latest'
-```
-
-Instead of the `abp` alias, you might want to use a modified alias, such as `apb-fh`, to not conflict w/ other versions that might be installed already on your machine.
+For more extensive documentation on APB development and apb command line options, please read the ansible playbook bundle [docs](https://github.com/ansibleplaybookbundle/ansible-playbook-bundle/tree/master/docs).
 
 ## TODO
 * Creates an OpenShift Jenkins if it does not exist in a project


### PR DESCRIPTION
Don't force the use of the containerised apb tools in the Makefile commands, instead apb should be installed locally using one of the recommended approaches https://github.com/ansibleplaybookbundle/ansible-playbook-bundle/blob/master/docs/apb_cli.md#installing-the-apb-tool

**Note**: Intend to make whatever changes are agreed here to all apb Makefiles in this org.