### PR TITLE
AEROGEAR-2575 Removal of the associating OpenShift build objects

### DIFF
--- a/roles/deprovision-buildfarm-apb/tasks/main.yml
+++ b/roles/deprovision-buildfarm-apb/tasks/main.yml
@@ -18,29 +18,46 @@
 
 - name: Delete AG-Digger Deployment Configs
   command: "oc delete dc/{{ item }} -n {{ namespace }}"
+  changed_when: false
   with_items:
   - '{{ ag_android_sdk.deployment.name }}'
   - '{{ ag_jenkins.deployment.name }}'
 
+- name: Delete AG-Jenkins Builds
+  command: "oc delete builds -n {{ namespace }} -l mobile-client-build=true"
+  changed_when: false
+
+- name: Delete AG-Jenkins Build Configs
+  command: "oc delete bc -n {{ namespace }} -l mobile-client-build=true"
+  changed_when: false
+
+- name: Delete AG-Jenkins Build Secrets
+  command: "oc delete secrets -n {{ namespace }} -l mobile-client-build=true"
+  changed_when: false
+
 - name: Delete AG-Digger Service Accounts
   command: "oc delete serviceaccounts/{{ item }} -n {{ namespace }}"
+  changed_when: false
   with_items:
   - '{{ ag_android_sdk.service.name }}'
   - '{{ ag_jenkins.service.name }}'
 
 - name: Delete AG-Digger Role Bindings
   command: "oc delete rolebindings/{{ item }} -n {{ namespace }}"
+  changed_when: false
   with_items:
   - '{{ ag_android_sdk.rolebinding.name }}'
   - '{{ ag_jenkins.rolebinding.name }}'
 
 - name: Delete AG-Digger secrets
   command: "oc delete secrets/{{ item }} -n {{ namespace }}"
+  changed_when: false
   with_items:
   - '{{ ag_digger_secret_name }}'
 
 - name: delete AG-Digger configmaps
   command: "oc delete configmaps/{{ item }} -n {{ namespace }}"
+  changed_when: false
   with_items:
   - '{{ ag_android_sdk.configmap.name }}'
   - '{{ ag_android_sdk.configmap.proxy }}'

--- a/roles/provision-buildfarm-apb/tasks/main.yml
+++ b/roles/provision-buildfarm-apb/tasks/main.yml
@@ -10,11 +10,12 @@
 
 - name: Create Mobile CI|CD secret
   command: "oc create -f /tmp/aerogear-digger.secret.yaml -n {{ namespace }}"
+  changed_when: false
 
 - name: Check for current Jenkins
   command: "oc get service {{ ag_jenkins.service.name }} -n {{ namespace }}"
-  failed_when: false
   changed_when: false
+  failed_when: false
   register: jenkins_check
 
 - name: Copy the jenkins template
@@ -48,10 +49,12 @@
 
 - name: Install Jenkins plugins
   shell: "bash /tmp/install-jenkins-plugins.sh {{ namespace }} {{ ag_jenkins.deployment.name }}"
+  changed_when: false
   register: install_jenkins_plugins
 
 - name: Get Jenkins - Mobile CI|CD URI
   shell: "oc get routes {{ ag_jenkins.route.name }} -n {{ namespace}}  | grep -v NAME | awk '{ print $2 }'"
+  changed_when: false
   register: get_jenkins_uri
 
 - set_fact:
@@ -65,6 +68,7 @@
 
 - name: Create OpenShift Jenkins Kubernetes Plugin ConfigMap
   command: "oc create -f /tmp/android.configmap.yaml -n {{ namespace }}"
+  changed_when: false
 
 - name: "Read Android SDK definition"
   set_fact:
@@ -88,9 +92,12 @@
 - name: "Deploy the Android SDK image"
   command: "oc new-app -f {{ buildfarm_templates_dir }}/android-sdk-persistent-template.json -n {{ namespace }}"
   register: android_create_result
-  failed_when:
-    - android_create_result.stderr and android_create_result.stderr != '' and 'already exists' not in android_create_result.stderr
-  changed_when: android_create_result.rc == 0 or (android_create_result.rc == 1 and 'created' in android_create_result.stdout)
+  changed_when: >
+    android_create_result.rc == 0 or
+    (android_create_result.rc == 1 and 'created' in android_create_result.stdout)
+  failed_when: >
+    android_create_result.stderr and android_create_result.stderr != '' and
+    'already exists' not in android_create_result.stderr
   tags:
   - deploy-sdk-pod
 
@@ -123,13 +130,14 @@
   rescue:
   - name: "Attempting redeploy of failed Pod"
     command: "oc deploy --retry dc/{{ ag_android_sdk.deployment.name }} -n {{ namespace }}"
+    changed_when: false
   when: not poller.stat.exists
 
 - name: "Get the Android SDK pod name"
   shell: "oc get pods -n {{ namespace }} | grep {{ ag_android_sdk.deployment.name }} | grep -v deploy | awk '{print$1}'"
+  changed_when: false
   failed_when: output.stdout == ""
   register: output
-  changed_when: False
   tags:
   - install-sdk
 
@@ -139,89 +147,89 @@
   tags:
   - install-sdk
 
--
-  block:
-    - include: update-secret.yml
-      vars:
-        status_message: Configuring Android SDK container
-        status_percentage: "40"
-        jenkins_uri: "{{ jenkins_route }}"
-        jenkins_preexists: "{{ jenkins_service_preexists }}"
+- block:
+  - include: update-secret.yml
+    vars:
+      status_message: Configuring Android SDK container
+      status_percentage: "40"
+      jenkins_uri: "{{ jenkins_route }}"
+      jenkins_preexists: "{{ jenkins_service_preexists }}"
 
-    - name: "Checks if android sdk is already installed"
-      stat:
-        path: "{{ android_sdk_home }}/tools/bin/sdkmanager"
-      register: sdk_folder
+  - name: "Checks if android sdk is already installed"
+    stat:
+      path: "{{ android_sdk_home }}/tools/bin/sdkmanager"
+    register: sdk_folder
 
-    - name: "Install the Android SDK"
-      command: "oc -n {{ namespace }} rsh {{ android_sdk_podname }} androidctl sdk install"
-      when: sdk_folder.stat.exists == False
+  - name: "Install the Android SDK"
+    command: "oc -n {{ namespace }} rsh {{ android_sdk_podname }} androidctl sdk install"
+    when: sdk_folder.stat.exists == False
 
-    -
-      name: Copy default config file
-      copy:
-          src: default.cfg
-          dest: /tmp/sdk.cfg
-          mode: 0777
-      when: ANDROID_SDK_AUTO_CONFIG|default('No') == 'Yes'
+  - name: Copy default config file
+    copy:
+      src: default.cfg
+      dest: /tmp/sdk.cfg
+      mode: 0777
+    when: ANDROID_SDK_AUTO_CONFIG|default('No') == 'Yes'
 
-    -
-      name: Create custom config file
-      copy:
-        content: "{{ ANDROID_SDK_CONFIG }}"
-        dest: /tmp/sdk.cfg
+  - name: Create custom config file
+    copy:
+      content: "{{ ANDROID_SDK_CONFIG }}"
+      dest: /tmp/sdk.cfg
+      mode: 0777
+    when: ANDROID_SDK_AUTO_CONFIG|default('No') == 'No' and ANDROID_SDK_CONFIG|default(' ') != ' '
+
+  - name: Send config file to android sdk container
+    command: "oc cp /tmp/sdk.cfg {{ namespace }}/{{ android_sdk_podname }}:/opt/tools/sdk.cfg"
+    changed_when: false
+
+  - name: "Sync Android Platform Versions via config"
+    command: "oc -n {{ namespace }} rsh {{ android_sdk_podname }} androidctl-sync /opt/tools/sdk.cfg"
+    changed_when: false
+    failed_when: "'Traceback' in rsh_cmd.stdout or 'Common Arguments' in rsh_cmd.stdout"
+    register: rsh_cmd
+
+  - name: "Installing Android SDK, this may take some time"
+    command: "oc -n {{ namespace }} rsh {{ android_sdk_podname }} androidctl-sync -y /opt/tools/sdk.cfg"
+    when: "'Accept?' in rsh_cmd.stdout"
+
+  - include: update-secret.yml
+    vars:
+      status_message: Configuring Gradle
+      status_percentage: "80"
+      jenkins_uri: "{{ jenkins_route }}"
+      jenkins_preexists: "{{ jenkins_service_preexists }}"
+
+  - name: "Check gradle wrapper exists"
+    command: "oc -n {{ namespace }} exec {{ android_sdk_podname }} -i -- bash -c 'stat {{ android_sdk_home }}/tools/templates/gradle/wrapper/gradlew'"
+    register: gradlew_status
+    failed_when: False
+    changed_when: False
+
+  - block:
+    - name: "Create required directory"
+      command: "oc -n {{ namespace }} exec {{ android_sdk_podname }} -i -- bash -c 'mkdir -p {{ android_sdk_home }}/tools/templates/gradle/wrapper'"
+      changed_when: false
+
+    - name: "Create temp folder"
+      file:
+        path: /tmp/aerogear-digger-installer
+        state: directory
         mode: 0777
-      when: ANDROID_SDK_AUTO_CONFIG|default('No') == 'No' and ANDROID_SDK_CONFIG|default(' ') != ' '
 
-    -
-      name: Send config file to android sdk container
-      command: "oc cp /tmp/sdk.cfg {{ namespace }}/{{ android_sdk_podname }}:/opt/tools/sdk.cfg" 
+    - name: "Copy gradlew to remote temp folder"
+      copy:
+        src: gradle-wrapper.tar.gz
+        dest: /tmp/aerogear-digger-installer/gradle-wrapper.tar.gz
+        mode: 0777
 
-    - name: "Sync Android Platform Versions via config"
-      command: "oc -n {{ namespace }} rsh {{ android_sdk_podname }} androidctl-sync /opt/tools/sdk.cfg"
-      register: rsh_cmd
-      failed_when: "'Traceback' in rsh_cmd.stdout or 'Common Arguments' in rsh_cmd.stdout"
+    - name: "Copy required tarball"
+      command: "oc -n {{ namespace }} rsync /tmp/aerogear-digger-installer/ {{ android_sdk_podname }}:{{ android_sdk_home }}/tools/templates/gradle/wrapper/ --include='gradle-wrapper.tar.gz'"
+      changed_when: false
 
-    - name: "Installing Android SDK, this may take some time"
-      command: "oc -n {{ namespace }} rsh {{ android_sdk_podname }} androidctl-sync -y /opt/tools/sdk.cfg"
-      when: "'Accept?' in rsh_cmd.stdout"
-
-    - include: update-secret.yml
-      vars:
-        status_message: Configuring Gradle
-        status_percentage: "80"
-        jenkins_uri: "{{ jenkins_route }}"
-        jenkins_preexists: "{{ jenkins_service_preexists }}"
-
-    - name: "Check gradle wrapper exists"
-      command: "oc -n {{ namespace }} exec {{ android_sdk_podname }} -i -- bash -c 'stat {{ android_sdk_home }}/tools/templates/gradle/wrapper/gradlew'"
-      register: gradlew_status
-      failed_when: False
-      changed_when: False
-
-    -
-      block:
-      - name: "Create required directory"
-        command: "oc -n {{ namespace }} exec {{ android_sdk_podname }} -i -- bash -c 'mkdir -p {{ android_sdk_home }}/tools/templates/gradle/wrapper'"
-
-      - name: "Create temp folder"
-        file:
-          path: /tmp/aerogear-digger-installer
-          state: directory
-          mode: 0777
-
-      - name: "Copy gradlew to remote temp folder"
-        copy:
-          src: gradle-wrapper.tar.gz
-          dest: /tmp/aerogear-digger-installer/gradle-wrapper.tar.gz
-          mode: 0777
-
-      - name: "Copy required tarball"
-        command: "oc -n {{ namespace }} rsync /tmp/aerogear-digger-installer/ {{ android_sdk_podname }}:{{ android_sdk_home }}/tools/templates/gradle/wrapper/ --include='gradle-wrapper.tar.gz'"
-
-      - name: "Unarchive gradle files"
-        command: "oc -n {{ namespace }} exec {{ android_sdk_podname }} -i -- bash -c 'tar -zxvf {{ android_sdk_home }}/tools/templates/gradle/wrapper/gradle-wrapper.tar.gz -C {{ android_sdk_home }}/tools/templates/gradle/wrapper'"
-      when: gradlew_status.rc != 0
+    - name: "Unarchive gradle files"
+      command: "oc -n {{ namespace }} exec {{ android_sdk_podname }} -i -- bash -c 'tar -zxvf {{ android_sdk_home }}/tools/templates/gradle/wrapper/gradle-wrapper.tar.gz -C {{ android_sdk_home }}/tools/templates/gradle/wrapper'"
+      changed_when: false
+    when: gradlew_status.rc != 0
   when: ANDROID_SDK_AUTO_CONFIG|default('No') == 'Yes' or ANDROID_SDK_CONFIG|default(' ') != ' '
 
 - include_tasks: update-secret.yml

--- a/roles/provision-buildfarm-apb/tasks/update-secret.yml
+++ b/roles/provision-buildfarm-apb/tasks/update-secret.yml
@@ -11,3 +11,4 @@
 
 - name: Create Mobile CI|CD secret
   command: "oc replace -f /tmp/aerogear-digger.secret.yaml -n {{ namespace }}"
+  changed_when: false


### PR DESCRIPTION
**JIRA** [AEROGEAR-2575](https://issues.jboss.org/browse/AEROGEAR-2575)
**CHANGELOG**
- [ ] delete jenkins builds
- [ ] delete jenkins build configs 
- [ ] delete jenkins secrets

**VERIFICATION**
1. Provision Mobile CI|CD
- [ ] `oc create -f file1.yml -n test1`
- [ ] `oc label bc/helloworld-android-pipeline1 mobile-client-build=true -n test1`
- [ ] `oc start-build helloworld-android-pipeline1 -n test1`
- [ ] `oc create secret generic helloworld-android-cert1 -n test1`
- [ ] `oc label secret/helloworld-android-cert1 mobile-client-build=true -n test1`
2. Deprovision Mobile CI|CD
- [ ] jenkins builds deleted
- [ ] jenkins build configs deleted
- [ ] jenkins build secrets deleted

```yaml
---
kind: BuildConfig
apiVersion: v1
metadata:
  name: helloworld-android-pipeline1
spec:
  source:
    git:
      uri: https://github.com/odra/helloworld-android-gradle.git
      ref: jenkins-apk-path
  strategy:
    jenkinsPipelineStrategy:
      env:
        -
          name: FH_CONFIG_CONTENT
          value: empty_content
        -
          name: BUILD_CONFIG
          value: debug
      jenkinsfilePath: Jenkinsfile
```